### PR TITLE
Fixed formatting error preventing import of mcf

### DIFF
--- a/CRM3/Scripts/plot_crm_flux_data.py
+++ b/CRM3/Scripts/plot_crm_flux_data.py
@@ -46,7 +46,7 @@ if (os.getenv('TEST') == 'TEST'):
 #
 #--- append  pathes to private folders to a python directory
 #
-    sys.path.append('/data/mta4/Script/Python3.10/MTA/')
+sys.path.append('/data/mta4/Script/Python3.10/MTA/')
 #
 #--- import several functions
 #


### PR DESCRIPTION
This PR corrects the formatting of the <code>plot_crm_flux_data.py</code> file, which prevented the import of mta_common_functions.

The script is executed as part of the following cronjob running on boba-v:

<code>4,9,14,19,24,29,34,39,44,49,54,59 * * * *  /data/mta4/Space_Weather/CRM3/Scripts/crm_table_wrap_script</code>

and the plots it creates are displayed on https://cxc.cfa.harvard.edu/mta/RADIATION_new/Orbit/orbit.html as External CRM Proton Fluence (left) and Attenuated CRM Proton Fluence (right) plots.

Testing:
- clone the <code>Space_Weather_New</code> repository and checkout to the <code>crm-plots</code> branch
- cd to the directory containing the <code>plot_crm_flux_data.py</code> file
- create a <code>test_plots</code> directory
- create test plot directory <code>test_plots/Orbit/Plots</code>
- execute the following commands, inspect crmpl.png and crmplatt.png plots in the test plot directories, and compare with the plots attached below

<code>import plot_crm_flux_data as pp
pp.html_dir = "test_plots/"
pp.plot_crm_flux_data()</code>

Next steps: remove dependency on <code>mta_common_functions</code>, the instances when this package is called (to read a file, to check if the variable is a number, to add a leading zero to a string) can be achieved with native python functions.

Note: a corresponding update need to be applied to the secondary code running on r2d2-v.
