### PR TITLE
Archive write fix

### DIFF
--- a/ACE/Scripts/update_ace_data_files.py
+++ b/ACE/Scripts/update_ace_data_files.py
@@ -20,6 +20,7 @@ import time
 from datetime import datetime
 import Chandra.Time
 import copy 
+import subprocess
 #
 #--- reading directory list
 #
@@ -630,8 +631,8 @@ def update_long_term_data(ndata):
     output: <ace_dir>/Data/longterm/ace_data.txt
     """
     dfile = ace_data + 'longterm/ace_data.txt'
-    data  = mcf.read_data_file(dfile)
-    atemp = re.split('\s+', data[-1])
+    last_line = subprocess.check_output(f"tail -n 1 {dfile}", shell=True, executable='/bin/csh').decode()
+    atemp = re.split('\s+', last_line)
 #
 #--- convert time in Chandra Time
 #

--- a/ACE/Scripts/update_ace_data_files.py
+++ b/ACE/Scripts/update_ace_data_files.py
@@ -651,18 +651,18 @@ def update_long_term_data(ndata):
             if ndata[2][m] != 0 or ndata[5][m] != 0:
                 continue
 
-        line = line + ndata[1][m]
-        line = line + '%3d'   % ndata[2][m]
-        line = line + line_adjust(ndata[3][m])
-        line = line + line_adjust(ndata[4][m])
-        line = line + '%3d'   % ndata[5][m]
-        line = line + line_adjust(ndata[6][m])
-        line = line + line_adjust(ndata[7][m])
-        line = line + line_adjust(ndata[8][m])
-        line = line + line_adjust(ndata[9][m])
-        line = line + line_adjust(ndata[10][m])
-        line = line + '%7.2f' % ndata[11][m]
-        line = line + '\n'
+            line = line + ndata[1][m]
+            line = line + '%3d'   % ndata[2][m]
+            line = line + line_adjust(ndata[3][m])
+            line = line + line_adjust(ndata[4][m])
+            line = line + '%3d'   % ndata[5][m]
+            line = line + line_adjust(ndata[6][m])
+            line = line + line_adjust(ndata[7][m])
+            line = line + line_adjust(ndata[8][m])
+            line = line + line_adjust(ndata[9][m])
+            line = line + line_adjust(ndata[10][m])
+            line = line + '%7.2f' % ndata[11][m]
+            line = line + '\n'
 
     if (os.getenv('TEST') == 'TEST'):
         dfile = test_out + '/ace_data.txt'


### PR DESCRIPTION
This PR adjusts the ACE lantern archive writing function to fix Issue #17 in which the ACE archive data files are recording data entires multiples times.

Through tests available in the MTA Notebook ACE_clean/clean_archive.ipynb, it is show how each repeated archive file is fixed.

This PR in particular implements the script changes necessary to fix the longterm ace archive file.