### PR TITLE
Include old proxy

### DIFF
--- a/GOES/Scripts/alert_hrc.py
+++ b/GOES/Scripts/alert_hrc.py
@@ -1,27 +1,26 @@
 #!/proj/sot/ska3/flight/bin/python
 import os
-import sys
 import argparse
 import getpass
 import traceback
-import subprocess
 import datetime
 import json
-import numpy as np
-from astropy.io import misc, ascii
-from astropy.table import Table, vstack, unique
+from astropy.io import ascii
 
 #
 #--- Define Directory Pathing
 #
 GOES_DIR = "/data/mta4/Space_Weather/GOES/Data"
 GOES_DATA_FILE = f"{GOES_DIR}/Gp_pchan_5m.txt"
-HRC_PROXY_DATA_FILE = f"{GOES_DIR}/hrc_proxy.h5"
 VIOL_RECORD_FILE = f"{GOES_DIR}/hrc_proxy_viol.json"
 
 NAMES = ('time', 'p1', 'p2a', 'p2b', 'p3', 'p4', 'p5',
          'p6', 'p7', 'p8a', 'p8b', 'p8c', 'p9', 'p10',
          'hrc_proxy', 'hrc_proxy_legacy')
+
+#Based on HRC Proxy differential values
+HRC_THRESHOLD = {'Warning': 6.2e4,
+                'Violation': 1.95e5}
 
 #Alert Email Addresses
 HRC_ADMIN = ['sot_ace_alert@cfa.harvard.edu']
@@ -30,14 +29,56 @@ HRC_ADMIN = ['sot_ace_alert@cfa.harvard.edu']
 def alert_hrc():
     dat = ascii.read(GOES_DATA_FILE, data_start=5, delimiter='\t', guess=False, names=NAMES)
     time, hrc_proxy, hrc_proxy_legacy = dat[-1]['time','hrc_proxy', 'hrc_proxy_legacy']
+    recent_data = {'time': time,
+                   'hrc_proxy': hrc_proxy,
+                   'hrc_proxy_legacy': hrc_proxy_legacy}
+
+    #Check current status of HRC proxy violations.
+    #If one has been found very recently, do not email about the violation again
+    with open(VIOL_RECORD_FILE) as f:
+        curr_viol = json.load(f)
+    
+    #Iterate over kinds of threshold and versions each proxy
+    content = ''
+    for kind in HRC_THRESHOLD.keys():
+        for proxy in ['hrc_proxy', 'hrc_proxy_legacy']:
+            if recent_data[proxy] > HRC_THRESHOLD[kind]:
+                #check if there was a similar kind of violation withing the last 24 hours
+                if viol_time_check(curr_viol, kind, proxy):
+                    content += f"{kind}: {proxy}\n"
+                    content += f"Observed: {recent_data[proxy]:.5e} at Time: {time}\n"
+                    content += f"Limit: {HRC_THRESHOLD[kind]:.3e} counts/sec.\n"
+                    content += f"{'-' * 20}\n"
+                    curr_viol[f"{kind}_{proxy}"] = recent_data
+    
+    if content != '':
+        send_mail(content, "HRC Proxy Violation", HRC_ADMIN)
+
+def send_mail(content, subject, admin):
+    """
+    send out a notification email to admin
+    """
+    content += f'This message was send to {" ".join(admin)}'
+    cmd = f'echo "{content}" | mailx -s "{subject}" {" ".join(admin)}'
+    os.system(cmd)
+
+def viol_time_check(curr_viol, kind, proxy):
+    """
+    Prevents spamming violaiton emails if the data is in violation, 
+    opting to send out a email if the specific violation was last warned more than 24 hours ago.
+    """
+    time_string = curr_viol[f"{kind}_{proxy}"]['time']
+    last = datetime.datetime.strptime(time_string, '%Y:%j:%H:%M')
+    now = datetime.datetime.utcnow()
+    return (now - last).seconds > 24 * 60 * 60
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-m", "--mode", choices = ['flight','test'], required = True, help = "Determine running mode.")
     parser.add_argument("-e", '--email', nargs = '*', required = False, help = "List of emails to recieve notifications")
     parser.add_argument("-g", "--goes", help = "Determine GOES + HRC data file path")
-    parser.add_argument("-p", "--hrc_proxy", help = "Determine realtime HRC proxy data file path")
-    parser.add_argument("-j", "--json", help = "Pass in custom data record for current state of HRC proxy violations.")
+    parser.add_argument("-j", "--json", help = "Pass in record for current state of HRC proxy violations.")
     args = parser.parse_args()
 
     if args.mode == 'test':
@@ -54,12 +95,7 @@ if __name__ == "__main__":
 #
         if args.goes:
             GOES_DATA_FILE = args.goes
-        if args.hrc_proxy:
-            HRC_PROXY_DATA_FILE = args.hrc_proxy
-        else:
-            OUT_DIR = f"{os.getcwd()}/test/outTest"
-            os.makedirs(OUT_DIR, exist_ok = True)
-            HRC_PROXY_DATA_FILE = f"{OUT_DIR}/hrc_proxy.h5"        
+
         if args.json:
             VIOL_RECORD_FILE = args.json
         else:
@@ -67,21 +103,18 @@ if __name__ == "__main__":
             #a typical script run more directly.
             OUT_DIR = f"{os.getcwd()}/test/outTest"
             os.makedirs(OUT_DIR, exist_ok = True)
-            temp_dict = {'in_viol': False,
-                         'last_viol_time': '2020:077:17:10:00',
-                         'content': '',
-                         'notified': True}
+            temp_dict = {"time": '2020:077:17:10',
+                         "hrc_proxy": 0,
+                         "hrc_proxy_legacy": 0}
             import copy
-            check_viol = {"warn_V1": copy.copy(temp_dict),
-                          "viol_V1": copy.copy(temp_dict),
-                          "warn_V2": copy.copy(temp_dict),
-                          "viol_V2": copy.copy(temp_dict)}
+            check_viol = {"Warning_hrc_proxy": copy.copy(temp_dict),
+                          "Violation_hrc_proxy": copy.copy(temp_dict),
+                          "Warning_hrc_proxy_legacy": copy.copy(temp_dict),
+                          "Violation_hrc_proxy_legacy": copy.copy(temp_dict)}
             
             VIOL_RECORD_FILE = f"{OUT_DIR}/hrc_proxy_viol.json"
             with open(VIOL_RECORD_FILE,'w') as f:
                 json.dump(check_viol, f, indent = 4)
-
-
         try:
             alert_hrc()
         except:

--- a/GOES/Scripts/alert_hrc.py
+++ b/GOES/Scripts/alert_hrc.py
@@ -25,8 +25,7 @@ NAMES = ('time', 'p1', 'p2a', 'p2b', 'p3', 'p4', 'p5',
 CSV_HEADER = ['time', 'hrc_proxy', 'hrc_proxy_legacy']
 
 #Based on HRC Proxy differential values
-HRC_THRESHOLD = {'Warning': 6.2e4,
-                'Violation': 1.95e5}
+HRC_THRESHOLD = {'Warning': 3.2e4}
 
 #Alert Email Addresses
 HRC_ADMIN = ['sot_ace_alert@cfa.harvard.edu']
@@ -59,7 +58,7 @@ def alert_hrc():
                     content += f"{'-' * 20}\n"
                     curr_viol[f"{kind}_{proxy}"] = recent_data
     
-    if content != '' and HRC_ADMIN != []:
+    if content != '' and len(HRC_ADMIN) > 0 :
         send_mail(content, "HRC Proxy Violation", HRC_ADMIN)
     with open(VIOL_RECORD_FILE, 'w') as f:
         json.dump(curr_viol, f, indent = 4)
@@ -128,9 +127,7 @@ if __name__ == "__main__":
                          "hrc_proxy_legacy": 0}
             import copy
             check_viol = {"Warning_hrc_proxy": copy.copy(temp_dict),
-                          "Violation_hrc_proxy": copy.copy(temp_dict),
-                          "Warning_hrc_proxy_legacy": copy.copy(temp_dict),
-                          "Violation_hrc_proxy_legacy": copy.copy(temp_dict)}
+                          "Warning_hrc_proxy_legacy": copy.copy(temp_dict)}
             
             VIOL_RECORD_FILE = f"{OUT_DIR}/hrc_proxy_viol.json"
             with open(VIOL_RECORD_FILE,'w') as f:

--- a/GOES/Scripts/alert_hrc.py
+++ b/GOES/Scripts/alert_hrc.py
@@ -92,7 +92,7 @@ def add_to_archive(recent_data, outfile):
         last_time = datetime.datetime.strptime(out.split()[0], '%Y:%j:%H:%M')
         #Send alert if the archive has not been recording for 15 minutes
         if (append_time - last_time).total_seconds() > 900:
-            content = f"Time discrepancy in {HRC_PROXY_DATA_FILE}\n{'-' * 40}\nTail: {out}New Data: {data_line}Investigate {__file__}\n"
+            content = f"Time discrepancy in {HRC_PROXY_DATA_FILE}\n{'-' * 40}\nTail: {out}New Data: {data_line}Investigate {__file__}\n"    
             send_mail(content, "Time Discrepancy in HRC Proxy Archive", ADMIN)
 
     else:

--- a/GOES/Scripts/alert_hrc.py
+++ b/GOES/Scripts/alert_hrc.py
@@ -1,0 +1,93 @@
+#!/proj/sot/ska3/flight/bin/python
+import os
+import sys
+import argparse
+import getpass
+import traceback
+import subprocess
+import datetime
+import json
+import numpy as np
+from astropy.io import misc, ascii
+from astropy.table import Table, vstack, unique
+
+#
+#--- Define Directory Pathing
+#
+GOES_DIR = "/data/mta4/Space_Weather/GOES/Data"
+GOES_DATA_FILE = f"{GOES_DIR}/Gp_pchan_5m.txt"
+HRC_PROXY_DATA_FILE = f"{GOES_DIR}/hrc_proxy.h5"
+VIOL_RECORD_FILE = f"{GOES_DIR}/hrc_proxy_viol.json"
+
+NAMES = ('time', 'p1', 'p2a', 'p2b', 'p3', 'p4', 'p5',
+         'p6', 'p7', 'p8a', 'p8b', 'p8c', 'p9', 'p10',
+         'hrc_proxy', 'hrc_proxy_legacy')
+
+#Alert Email Addresses
+HRC_ADMIN = ['sot_ace_alert@cfa.harvard.edu']
+
+
+def alert_hrc():
+    dat = ascii.read(GOES_DATA_FILE, data_start=5, delimiter='\t', guess=False, names=NAMES)
+    time, hrc_proxy, hrc_proxy_legacy = dat[-1]['time','hrc_proxy', 'hrc_proxy_legacy']
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--mode", choices = ['flight','test'], required = True, help = "Determine running mode.")
+    parser.add_argument("-e", '--email', nargs = '*', required = False, help = "List of emails to recieve notifications")
+    parser.add_argument("-g", "--goes", help = "Determine GOES + HRC data file path")
+    parser.add_argument("-p", "--hrc_proxy", help = "Determine realtime HRC proxy data file path")
+    parser.add_argument("-j", "--json", help = "Pass in custom data record for current state of HRC proxy violations.")
+    args = parser.parse_args()
+
+    if args.mode == 'test':
+#
+#--- Redefine Admin for sending notification email in test mode
+#
+        if args.email != None:
+            HRC_ADMIN = args.email
+        else:
+            HRC_ADMIN = [os.popen(f"getent aliases | grep {getpass.getuser()}").read().split(":")[1].strip()]
+
+#
+#--- Redefine pathing for GOES and HRC PROXY data files
+#
+        if args.goes:
+            GOES_DATA_FILE = args.goes
+        if args.hrc_proxy:
+            HRC_PROXY_DATA_FILE = args.hrc_proxy
+        else:
+            OUT_DIR = f"{os.getcwd()}/test/outTest"
+            os.makedirs(OUT_DIR, exist_ok = True)
+            HRC_PROXY_DATA_FILE = f"{OUT_DIR}/hrc_proxy.h5"        
+        if args.json:
+            VIOL_RECORD_FILE = args.json
+        else:
+            #while roundabout, writing this empty test violation record to a separate file and reading it again test's 
+            #a typical script run more directly.
+            OUT_DIR = f"{os.getcwd()}/test/outTest"
+            os.makedirs(OUT_DIR, exist_ok = True)
+            temp_dict = {'in_viol': False,
+                         'last_viol_time': '2020:077:17:10:00',
+                         'content': '',
+                         'notified': True}
+            import copy
+            check_viol = {"warn_V1": copy.copy(temp_dict),
+                          "viol_V1": copy.copy(temp_dict),
+                          "warn_V2": copy.copy(temp_dict),
+                          "viol_V2": copy.copy(temp_dict)}
+            
+            VIOL_RECORD_FILE = f"{OUT_DIR}/hrc_proxy_viol.json"
+            with open(VIOL_RECORD_FILE,'w') as f:
+                json.dump(check_viol, f, indent = 4)
+
+
+        try:
+            alert_hrc()
+        except:
+            traceback.print_exc()
+    else:
+        try:
+            alert_hrc()
+        except:
+            traceback.print_exc()

--- a/GOES/Scripts/check_archive.py
+++ b/GOES/Scripts/check_archive.py
@@ -25,7 +25,7 @@ def check_cadence():
     out = subprocess.check_output(f"tail -n 1 {ARCHIVE_FILE}", shell=True, executable='/bin/csh').decode()
     last_time = datetime.datetime.strptime(out.split(",")[0], '%Y:%j:%H:%M')
     if (now - last_time).total_seconds() > TIME_DIFF:
-        content = f"Time discrepancy in {ARCHIVE_FILE}\n{'-' * 40}\nTail: {out}Current Time: {now.strftime('%Y:%j:%H:%M')}\n"    
+        content = f"Time discrepancy in {ARCHIVE_FILE}\n{'-' * 40}\nTail of file: {out}Current Time: {now.strftime('%Y:%j:%H:%M')}\n"    
         send_mail(content, "Time Discrepancy in HRC Proxy Archive", ADMIN)
 
 if __name__ == "__main__":

--- a/GOES/Scripts/check_archive.py
+++ b/GOES/Scripts/check_archive.py
@@ -1,0 +1,79 @@
+#!/proj/sot/ska3/flight/bin/python
+import os
+import sys
+import datetime
+import subprocess
+import argparse
+import traceback
+import getpass
+
+ARCHIVE_FILE = "/data/mta4/Space_Weather/GOES/Data/hrc_proxy.csv"
+ADMIN = ['mtadude@cfa.harvard.edu']
+#Due to the latest data from SWPC being 15 minutes behind, this data will always have at minimum a 15 minute delay.
+TIME_DIFF = 1800 #30 minutes in seconds
+
+def send_mail(content, subject, admin):
+    """
+    send out a notification email to admin
+    """
+    content += f'This message was send to {" ".join(admin)}'
+    cmd = f'echo "{content}" | mailx -s "{subject}" {" ".join(admin)}'
+    os.system(cmd)
+
+def check_cadence():
+    now = datetime.datetime.utcnow()
+    out = subprocess.check_output(f"tail -n 1 {ARCHIVE_FILE}", shell=True, executable='/bin/csh').decode()
+    last_time = datetime.datetime.strptime(out.split(",")[0], '%Y:%j:%H:%M')
+    if (now - last_time).total_seconds() > TIME_DIFF:
+        content = f"Time discrepancy in {ARCHIVE_FILE}\n{'-' * 40}\nTail: {out}Current Time: {now.strftime('%Y:%j:%H:%M')}\n"    
+        send_mail(content, "Time Discrepancy in HRC Proxy Archive", ADMIN)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--mode", choices = ['flight','test'], required = True, help = "Determine running mode.")
+    parser.add_argument("-e", '--email', nargs = '*', required = False, help = "List of emails to recieve notifications")
+    parser.add_argument("-a", "--archive", help="Determine longterm record file path for HRC proxy")
+    args = parser.parse_args()
+
+    if args.mode == 'test':
+#
+#--- Redefine Admin for sending notification email in test mode
+#
+        if args.email != None:
+            ADMIN = args.email
+        else:
+            ADMIN = [os.popen(f"getent aliases | grep {getpass.getuser()}").read().split(":")[1].strip()]
+
+        OUT_DIR = f"{os.getcwd()}/test/outTest"
+        os.makedirs(OUT_DIR, exist_ok = True)
+        if args.archive:
+            ARCHIVE_FILE = args.archive
+        else:
+            ARCHIVE_FILE = f"{OUT_DIR}/hrc_proxy.csv"
+
+        try:
+            check_cadence()
+        except:
+            traceback.print_exc()
+
+    elif args.mode == "flight":
+#
+#--- Create a lock file and exit strategy in case of race conditions
+#
+        name = os.path.basename(__file__).split(".")[0]
+        user = getpass.getuser()
+        if os.path.isfile(f"/tmp/{user}/{name}.lock"):
+            notification = f"Lock file exists as /tmp/{user}/{name}.lock. Process already running/errored out. Check calling scripts/cronjob/cronlog."
+            send_mail(notification,f"Stalled Script: {name}", ADMIN)
+            sys.exit(notification)
+        else:
+            os.system(f"mkdir -p /tmp/{user}; touch /tmp/{user}/{name}.lock")
+
+        try:
+            check_cadence()
+        except:
+            traceback.print_exc()
+#
+#--- Remove lock file once process is completed
+#
+        os.system(f"rm /tmp/{user}/{name}.lock")

--- a/GOES/Scripts/check_archive_main_script
+++ b/GOES/Scripts/check_archive_main_script
@@ -1,0 +1,3 @@
+cd /data/mta4/Space_Weather/GOES/Scripts
+
+/data/mta4/Space_Weather/GOES/Scripts/check_archive.py -m flight

--- a/GOES/Scripts/check_archive_wrap_script
+++ b/GOES/Scripts/check_archive_wrap_script
@@ -1,0 +1,1 @@
+/proj/sot/ska3/flight/bin/skare /bin/tcsh  < /data/mta4/Space_Weather/GOES/Scripts/check_archive_main_script

--- a/GOES/Scripts/goes_main_script
+++ b/GOES/Scripts/goes_main_script
@@ -1,5 +1,6 @@
 cd /data/mta4/Space_Weather/GOES/Scripts
 
 /data/mta4/Space_Weather/GOES/Scripts/plot_goes_data.py -m flight
-/data/mta4/Space_Weather/GOES/Scripts/update_goes_differential_page.py
+/data/mta4/Space_Weather/GOES/Scripts/update_goes_differential_page.py -m flight
+/data/mta4/Space_Weather/GOES/Scripts/alert_hrc.py -m flight
 /data/mta4/Space_Weather/GOES/Scripts/update_goes_integrate_page.py

--- a/GOES/Scripts/update_goes_differential_page.py
+++ b/GOES/Scripts/update_goes_differential_page.py
@@ -267,7 +267,7 @@ def make_two_hour_table():
 
     line = line + '\tHRC Proxy Legacy is defined as:\n\n'
     line = line + '\tHRC Proxy Legacy = 6000 * P5P6 + 270000 * P7 + 100000 * P8ABC\n\n'
-    line = line + '\twhere P5P6 is a combination of P5 and P56 and P8ABC is a combination of P8A, P8B, and P8C.\n'
+    line = line + '\twhere P5P6 is a combination of P5 and P6 and P8ABC is a combination of P8A, P8B, and P8C.\n'
 #
 #---  print out data file for CRM use
 #
@@ -481,8 +481,6 @@ def compute_hrc(data):
     c11 = data[11][1]
 
     hrc = []
-    if len(c5) < 1:
-        exit(1)
 
     for k in range(0, len(c5)):
         try:
@@ -518,8 +516,6 @@ def compute_pre2020_hrc(data):
     p8c = data[10][1]
 
     hrc = []
-    if len(p5) < 1:
-        exit(1)
 
     p5p6 = combine_rates([p5, p6], ('P5', 'P6'))
     p8abc = combine_rates([p8a, p8b, p8c], ('P8A', 'P8B', 'P8C'))
@@ -567,7 +563,9 @@ def adjust_format(val):
 
 def send_mail(content, subject, admin):
     """
-    send out a notification email to admin
+    send out a notification email to admin in case the
+    script is found to be stalling, which would impact data file
+    used in hrc proxy alerting
     """
     content += f'This message was send to {" ".join(admin)}'
     cmd = f'echo "{content}" | mailx -s "{subject}" {" ".join(admin)}'

--- a/GOES/Scripts/update_goes_differential_page.py
+++ b/GOES/Scripts/update_goes_differential_page.py
@@ -28,7 +28,7 @@ import argparse
 GOES_DIR = '/data/mta4/Space_Weather/GOES'
 GOES_DATA_DIR = f"{GOES_DIR}/Data"
 GOES_TEMPLATE_DIR = f"{GOES_DIR}/Scripts/Template"
-HTML_DIR = '/data/mta4/www/RADIATION_new/'
+HTML_GOES_DIR = '/data/mta4/www/RADIATION_new/GOES'
 
 #
 #--- json data locations proton and electron
@@ -96,7 +96,7 @@ def update_goes_differential_page():
 #
 #--- update the page
 #
-    outfile = f"{HTML_DIR}/GOES/goes_pchan_p.html"
+    outfile = f"{HTML_GOES_DIR}/goes_pchan_p.html"
     with open(outfile, 'w') as fo:
         fo.write(line)
 
@@ -494,15 +494,15 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.mode == 'test':
-        OUT_DIR = f"{os.getcwd}/test/outTest"
+        OUT_DIR = f"{os.getcwd()}/test/outTest"
         os.makedirs(OUT_DIR, exist_ok = True)
         GOES_TEMPLATE_DIR = f"{os.getcwd()}/Template"
         if args.path:
             GOES_DATA_DIR = args.path
-            HTML_DIR = args.path
+            HTML_GOES_DIR = args.path
         else:
             GOES_DATA_DIR = OUT_DIR
-            HTML_DIR = OUT_DIR
+            HTML_GOES_DIR = OUT_DIR
         update_goes_differential_page()
     else:
         update_goes_differential_page()

--- a/GOES/Scripts/update_goes_differential_page.py
+++ b/GOES/Scripts/update_goes_differential_page.py
@@ -22,6 +22,7 @@ import json
 import numpy as np
 import argparse
 import traceback
+import getpass
 #
 #--- Define Directory Pathing
 #
@@ -609,7 +610,6 @@ if __name__ == "__main__":
 #
 #--- Create a lock file and exit strategy in case of race conditions
 #
-        import getpass
         name = os.path.basename(__file__).split(".")[0]
         user = getpass.getuser()
         if os.path.isfile(f"/tmp/{user}/{name}.lock"):

--- a/GOES/Scripts/update_goes_differential_page.py
+++ b/GOES/Scripts/update_goes_differential_page.py
@@ -31,22 +31,14 @@ for ent in data:
     var   = atemp[1].strip()
     line  = atemp[0].strip()
     exec("%s = %s" %(var, line))
-#for writing out files in test directory
-if (os.getenv('TEST') == 'TEST'):
-    os.system('mkdir -p TestOut')
-    test_out = os.getcwd() + '/TestOut'
 #
-#--- append path to a private folder
+#--- Define Directory Pathing
 #
-sys.path.append(goes_dir)
-sys.path.append('/data/mta4/Script/Python3.10/MTA/')
+GOES_DIR = '/data/mta4/Space_Weather/GOES'
+GOES_DATA_DIR = f"{GOES_DIR}/Data"
+GOES_TEMPLATE_DIR = f"{GOES_DIR}/Scripts/Template"
+HTML_DIR = '/data/mta4/www/RADIATION_new/'
 
-###`import mta_common_functions     as mcf
-#
-#--- set a temporary file name
-#
-rtail  = int(time.time()*random.random())
-zspace = '/tmp/zspace' + str(rtail)
 #
 #--- json data locations proton and electron
 #
@@ -58,11 +50,6 @@ proton_list = ['1020-1860 keV',   '1900-2300 keV',   '2310-3340 keV',    '3400-6
                '5840-11000 keV',  '11640-23270 keV', '25900-38100 keV',  '40300-73400 keV',\
                '83700-98500 keV', '99900-118000 keV','115000-143000 keV','160000-242000 keV',\
                '276000-404000 keV']
-#
-#--- goes data directory
-#
-data_dir  = goes_dir + 'Data/'
-templ_dir = goes_dir + 'Scripts/Template/'
 #
 #--- current goes satellite #
 #
@@ -82,7 +69,7 @@ def update_goes_differential_page():
 #
 #--- read header template
 #
-    hfile = templ_dir + 'G_header'
+    hfile = f"{GOES_TEMPLATE_DIR}/G_header"
     with open(hfile, 'r') as f:
         line = f.read()
 #
@@ -95,19 +82,19 @@ def update_goes_differential_page():
 #
 #--- add energy range note
 #
-    hfile = templ_dir + 'channel_energy_list'
+    hfile = f"{GOES_TEMPLATE_DIR}/channel_energy_list"
     with open(hfile, 'r') as f:
         line = line + f.read()
 #
 #--- add the image link
 #
-    hfile = templ_dir + 'Gp_image_diff'
+    hfile = f"{GOES_TEMPLATE_DIR}/Gp_image_diff"
     with open(hfile, 'r') as f:
         line = line + f.read()
 #
 #--- add footer
 #
-    hfile = templ_dir + 'G_footer'
+    hfile = f"{GOES_TEMPLATE_DIR}/G_footer"
     with open(hfile, 'r') as f:
         line = line + f.read()
 #
@@ -118,11 +105,7 @@ def update_goes_differential_page():
 #
 #--- update the page
 #
-    ####outfile = html_dir + 'GOES/goes16_pchan_p.html'
-    outfile = html_dir + 'GOES/goes_pchan_p.html'
-    #for writing out files in test directory
-    if (os.getenv('TEST') == 'TEST'):
-        outfile = test_out + "/" + os.path.basename(outfile)
+    outfile = f"{HTML_DIR}/GOES/goes_pchan_p.html"
     with open(outfile, 'w') as fo:
         fo.write(line)
 
@@ -261,10 +244,7 @@ def make_two_hour_table():
 #
 #---  print out data file for CRM use
 #
-    outfile = data_dir + 'Gp_pchan_5m.txt'\
-    #for writing out files in test directory
-    if (os.getenv('TEST') == 'TEST'):
-        outfile = test_out + "/" + os.path.basename(outfile)
+    outfile = f"{GOES_DATA_DIR}/Gp_pchan_5m.txt"
     with open(outfile, 'w') as fo:
         fo.write(aline)
 

--- a/GOES/Scripts/update_goes_differential_page.py
+++ b/GOES/Scripts/update_goes_differential_page.py
@@ -19,8 +19,7 @@ import datetime
 import Chandra.Time
 import urllib.request
 import json
-import random
-import numpy
+import numpy as np
 import argparse
 #
 #--- Define Directory Pathing
@@ -45,6 +44,28 @@ proton_list = ['1020-1860 keV',   '1900-2300 keV',   '2310-3340 keV',    '3400-6
 #--- current goes satellite #
 #
 satellite = "Primary"
+
+# GOES-16+ Energy bands (keV) and combinations
+DE = {'P1': [1860., 1020.],
+      'P2A': [2300., 1900.],
+      'P2B': [3340., 2310.],
+      'P3': [6480., 3400.],
+      'P4': [11000., 5840.],
+      'P5': [23270., 11640.],
+      'P6': [38100., 25900.],
+      'P7': [73400., 40300.],
+      'P8A': [98500., 83700.],
+      'P8B': [118000., 99900.],
+      'P8C': [143000., 115000.],
+      'P9': [242000., 160000.],
+      'P5P6': [23270., 11640.],
+      'P8ABC': [143000., 83700.],
+      'P8ABCP9': [242000., 83700.]}
+
+# Add delta_e to each list
+for key in DE.keys():
+    de = DE[key]
+    de.append(de[0] - de[1])
 
 #----------------------------------------------------------------------------
 #-- update_goes_differential_page: update goes differential html page      --
@@ -192,38 +213,38 @@ def make_two_hour_table():
 #
     line = line + '\tAVERAGE\t\t\t'
 
-    line = line + adjust_format(numpy.mean(p_data[0][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[1][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[2][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[3][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[4][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[5][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[6][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[7][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[8][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[9][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[10][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[11][1])) + "\t"
-    line = line + adjust_format(numpy.mean(p_data[12][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[0][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[1][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[2][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[3][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[4][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[5][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[6][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[7][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[8][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[9][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[10][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[11][1])) + "\t"
+    line = line + adjust_format(np.mean(p_data[12][1])) + "\t"
 
-    line = line + "%5.0f\t\n" % (numpy.mean(hrc_val))
+    line = line + "%5.0f\t\n" % (np.mean(hrc_val))
 #
     line = line + '\tFLUENCE\t\t\t'
-    line = line + adjust_format(numpy.sum(p_data[0][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[1][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[2][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[3][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[4][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[5][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[6][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[7][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[8][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[9][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[10][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[11][1])) + "\t"
-    line = line + adjust_format(numpy.sum(p_data[12][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[0][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[1][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[2][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[3][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[4][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[5][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[6][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[7][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[8][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[9][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[10][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[11][1])) + "\t"
+    line = line + adjust_format(np.sum(p_data[12][1])) + "\t"
 
-    line = line + "%5.0f\t\n" % (numpy.sum(hrc_val))
+    line = line + "%5.0f\t\n" % (np.sum(hrc_val))
 
     line = line +'\n'
     line = line + '\tHRC Proxy is defined as:\n'
@@ -462,6 +483,23 @@ def compute_hrc(data):
 
     return hrc
 
+#----------------------------------------------------------------------------
+#-- compute_pre2020_hrc: compute hrc proxy value                           --
+#----------------------------------------------------------------------------
+def compute_pre2020_hrc(data):
+    pass
+
+def combine_rates(data_list, channel_name):
+    """
+    Return combined rates for multiple channels
+    """
+    combined = np.zeros(len(data_list[0]))
+    for i, data in enumerate(data_list):
+        print(f"{combined}, {i}")
+        combined = combined + (np.array(data) * DE[channel_name[i]][2])
+    print(combined)
+    delta_e = DE[channel_name[-1]][0] - DE[channel_name[0]][1]
+    return list(combined / delta_e)
 #----------------------------------------------------------------------------
 #----------------------------------------------------------------------------
 #----------------------------------------------------------------------------

--- a/GOES/Scripts/update_goes_differential_page.py
+++ b/GOES/Scripts/update_goes_differential_page.py
@@ -21,16 +21,7 @@ import urllib.request
 import json
 import random
 import numpy
-
-path = '/data/mta4/Space_Weather/house_keeping/dir_list'
-with open(path, 'r') as f:
-    data = [line.strip() for line in f.readlines()]
-
-for ent in data:
-    atemp = re.split(':', ent)
-    var   = atemp[1].strip()
-    line  = atemp[0].strip()
-    exec("%s = %s" %(var, line))
+import argparse
 #
 #--- Define Directory Pathing
 #
@@ -497,6 +488,22 @@ def adjust_format(val):
 #----------------------------------------------------------------------------
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--mode", choices = ['flight','test'], required = True, help = "Determine running mode.")
+    parser.add_argument("-p", "--path", help = "Determine data output file path")
+    args = parser.parse_args()
 
-    update_goes_differential_page()
+    if args.mode == 'test':
+        OUT_DIR = f"{os.getcwd}/test/outTest"
+        os.makedirs(OUT_DIR, exist_ok = True)
+        GOES_TEMPLATE_DIR = f"{os.getcwd()}/Template"
+        if args.path:
+            GOES_DATA_DIR = args.path
+            HTML_DIR = args.path
+        else:
+            GOES_DATA_DIR = OUT_DIR
+            HTML_DIR = OUT_DIR
+        update_goes_differential_page()
+    else:
+        update_goes_differential_page()
 


### PR DESCRIPTION
This PR implements an hrc_proxy alert into the GOES script run with the following approach criteria.

- Include MTA coding standard testing methods into the update_goes_differential_page.py script
- Include function to calculate the legacy HRC Proxy and record this value in the webpage and Gp_pchan_5min.txt file
- Creates a new alert_hrc.py script for processing Gp_pchan_5min.txt HRC Proxy columns and recording them in an archive file separate from goes_data_r.txt
- Implements email alerts for proxy violations, stalling of processing scripts, and time discrepancy in records on the HRC Proxy archive file.


Note that in this specific case, formatting the Gp_pchan_5min.txt file does not affect the CRM3 space weather script which uses the file as its file-reading string-splitting setup only operates on earlier columns. Both the new and old formats have been tested on the create_crm_summary_table.py script and are functional.