### PR TITLE
kill the stalling process to allow for current run to continue

### DIFF
--- a/GOES/Scripts/update_goes_differential_page.py
+++ b/GOES/Scripts/update_goes_differential_page.py
@@ -615,8 +615,13 @@ if __name__ == "__main__":
             send_mail(notification,f"Stalled Script: {name}", ADMIN)
             with open(f"/tmp/{user}/{name}.lock") as f:
                 pid = int(f.readlines()[-1].strip())
+            #Kill old stalling process and remove corresponding lock file.
+            os.remove(f"/tmp/{user}/{name}.lock")
             os.kill(pid,signal.SIGTERM)
+            #Generate lock file for the current corresponding process
+            os.system(f"mkdir -p /tmp/{user}; echo '{os.getpid()}' > /tmp/{user}/{name}.lock")
         else:
+            #Previous script run must have completed successfully. Prepare lock file for this script run.
             os.system(f"mkdir -p /tmp/{user}; echo '{os.getpid()}' > /tmp/{user}/{name}.lock")
 
         update_goes_differential_page()


### PR DESCRIPTION
Considering the importance of update_goes_differential_page now for hrc alerting, this change gives the script capability to kill previous cronjob runs of the script if they are stalling. The previous approach would prioritize completing the original script run rather than staring a new one, in case the script required a set of intermediary files to operate consistently. As this is not a requirement for this script and we'd prefer to not wait, the killing of previous processes is now preferable.