### PR TITLE
Avoid spam

### DIFF
--- a/GOES/Scripts/check_archive.py
+++ b/GOES/Scripts/check_archive.py
@@ -7,7 +7,9 @@ import argparse
 import traceback
 import getpass
 
-ARCHIVE_FILE = "/data/mta4/Space_Weather/GOES/Data/hrc_proxy.csv"
+
+DATA_DIR = "/data/mta4/Space_Weather/GOES/Data"
+ARCHIVE_FILE = f"{DATA_DIR}/hrc_proxy.csv"
 ADMIN = ['mtadude@cfa.harvard.edu']
 #Due to the latest data from SWPC being 15 minutes behind, this data will always have at minimum a 15 minute delay.
 TIME_DIFF = 1800 #30 minutes in seconds
@@ -24,8 +26,17 @@ def check_cadence():
     now = datetime.datetime.utcnow()
     out = subprocess.check_output(f"tail -n 1 {ARCHIVE_FILE}", shell=True, executable='/bin/csh').decode()
     last_time = datetime.datetime.strptime(out.split(",")[0], '%Y:%j:%H:%M')
-    if (now - last_time).total_seconds() > TIME_DIFF:
-        content = f"Time discrepancy in {ARCHIVE_FILE}\n{'-' * 40}\nTail of file: {out}Current Time: {now.strftime('%Y:%j:%H:%M')}\n"    
+    if os.path.isfile(f"{DATA_DIR}/check_archive.viol"):
+        #if we are in violation with a time discrepancy, do nothing until we are no longer in violation, then send email
+        if (now - last_time).total_seconds() < TIME_DIFF:
+            content = f"Time discrepancy in {ARCHIVE_FILE} has ended.\n{'-' * 40}\nTail of file: {out}Current Time: {now.strftime('%Y:%j:%H:%M')}\n"
+            send_mail(content, "HRC Proxy Archive Resumed", ADMIN)
+            os.remove(f"{DATA_DIR}/check_archive.viol")
+    #If we have no record of a time violation, but then find one, write the viol file and send email
+    elif (now - last_time).total_seconds() > TIME_DIFF:
+        content = f"Time discrepancy in {ARCHIVE_FILE}\n{'-' * 40}\nTail of file: {out}Current Time: {now.strftime('%Y:%j:%H:%M')}\n"
+        with open(f"{DATA_DIR}/check_archive.viol",'w') as f:
+            f.write(content)
         send_mail(content, "Time Discrepancy in HRC Proxy Archive", ADMIN)
 
 if __name__ == "__main__":
@@ -44,12 +55,12 @@ if __name__ == "__main__":
         else:
             ADMIN = [os.popen(f"getent aliases | grep {getpass.getuser()}").read().split(":")[1].strip()]
 
-        OUT_DIR = f"{os.getcwd()}/test/outTest"
-        os.makedirs(OUT_DIR, exist_ok = True)
+        DATA_DIR = f"{os.getcwd()}/test/outTest"
+        os.makedirs(DATA_DIR, exist_ok = True)
         if args.archive:
             ARCHIVE_FILE = args.archive
         else:
-            ARCHIVE_FILE = f"{OUT_DIR}/hrc_proxy.csv"
+            ARCHIVE_FILE = f"{DATA_DIR}/hrc_proxy.csv"
 
         try:
             check_cadence()

--- a/GOES/Scripts/update_goes_differential_page.py
+++ b/GOES/Scripts/update_goes_differential_page.py
@@ -639,7 +639,10 @@ if __name__ == "__main__":
             #Previous script run must have completed successfully. Prepare lock file for this script run.
             os.system(f"mkdir -p /tmp/{user}; echo '{os.getpid()}' > /tmp/{user}/{name}.lock")
 
-        update_goes_differential_page()
+        try:
+            update_goes_differential_page()
+        except:
+            traceback.print_exc()
 #
 #--- Remove lock file once process is completed
 #


### PR DESCRIPTION
To prevent spam emails, hrc proxy violation procedure now refactored to only send two emails in case of time discrepancy. The first being a notification that the hrc proxy archive is thirty minutes behind the current time. The second being a notification that the time discrepancy is gone and we are now up to date again.