### PR TITLE
correction to avoid runtime warning of numpy mean on empty array

### DIFF
--- a/ACE/Scripts/alert_ace.py
+++ b/ACE/Scripts/alert_ace.py
@@ -4,7 +4,7 @@
 **alert_ace.py**: Run ACE alerts.
 
 :Author: W. Aaron (william.aaron@cfa.harvard.edu)
-:Last Updated: Jan 14, 2025
+:Last Updated: Mar 03, 2025
 
 """
 
@@ -77,9 +77,12 @@ def alert_ace():
         ace_table["cxotime"].data >= two_hours_ago, ace_table[_P3_CHANNEL] > 0
     )
     data_select = ace_table[sel]
-    p130f = (
-        np.mean(data_select[_P3_CHANNEL].data) * 7200
-    )  #: Calculates the fluence with available data.
+    if len(data_select) > 0:
+        p130f = (
+            np.mean(data_select[_P3_CHANNEL].data) * 7200
+        )  #: Calculates the fluence with available data.
+    else:
+        p130f = -1e5 #: No valid data to send alert.
 
     #
     # ---Determine if Alerting


### PR DESCRIPTION
In the alert_ace.py script, the alert is sent on the last two hour fluence data for the ACE P3 channel. Under normal operations, it's possible for this data to not be available from the SWPC, in which case a -1e5 data marker is used for that time point. We do not factor this invalid data into our calculation. 

However, if the last two hours of data are invalid, then the script would end up calculating the mean of the ACE P3 channel fluence data onto an empty array which throws a runtime warning. This has now been fixed by including a check for whether it is empty or not.