### PR TITLE
TLE time correction

### DIFF
--- a/TLE/Scripts/create_orbital_data_files.py
+++ b/TLE/Scripts/create_orbital_data_files.py
@@ -661,8 +661,6 @@ def ut_in_secs(year, mon, day, hh, mm, ss):
     mm = int(float(mm))
     ss = int(float(ss))
 
-    #uts = (datetime(year, mon, day, hh, mm, ss) - datetime(1970, 1, 1)).total_seconds()
-    #uts += 86400.0
     uts = datetime(year,mon,day,hh,mm,ss, tzinfo=timezone.utc).timestamp()
 
     return uts

--- a/TLE/Scripts/create_orbital_data_files.py
+++ b/TLE/Scripts/create_orbital_data_files.py
@@ -14,7 +14,7 @@ import time
 import math
 import numpy
 from cxotime import CxoTime
-from datetime import datetime
+from datetime import datetime, timezone
 import calendar
 import argparse
 import getpass
@@ -561,7 +561,7 @@ def convert_to_gsm(sat):
         ss = float(atemp[-1])
 
         uts = ut_in_secs(year, mon, day, hh, mm, ss)
-        psi = geopack.recalc(uts)
+        psi = geopack.recalc(uts) #: Despite not being used, a bug in geopack.geigeo does not initialize the cgst variable correctly without running this first :(
         #
         # --- get the satellite postion in x, y, z
         #
@@ -661,8 +661,9 @@ def ut_in_secs(year, mon, day, hh, mm, ss):
     mm = int(float(mm))
     ss = int(float(ss))
 
-    uts = (datetime(year, mon, day, hh, mm, ss) - datetime(1970, 1, 1)).total_seconds()
-    uts += 86400.0
+    #uts = (datetime(year, mon, day, hh, mm, ss) - datetime(1970, 1, 1)).total_seconds()
+    #uts += 86400.0
+    uts = datetime(year,mon,day,hh,mm,ss, tzinfo=timezone.utc).timestamp()
 
     return uts
 


### PR DESCRIPTION
The TLE script set calculated epoch time from date information via a custom function called ut_in_secs(). This function incorrectly added an extra days worth of seconds to the epoch time count, offsetting the time information by one day.

This has been converted to use Python DateTime library conventions instead.