### PR TITLE
Xmm spam hotfix

### DIFF
--- a/XMM/Scripts/.nfs00000000efb5103400003021
+++ b/XMM/Scripts/.nfs00000000efb5103400003021
@@ -1,1 +1,0 @@
-tput: unknown terminal "dummy"

--- a/XMM/Scripts/check_mta_xmm_alert_page.py
+++ b/XMM/Scripts/check_mta_xmm_alert_page.py
@@ -363,11 +363,6 @@ def keep_record(time, alt, l1):
     with open(outfile, 'w') as fo:
         fo.write(line)
 
-    if (os.getenv('TEST') != 'TEST'):
-        cmd = 'cat ' + zspace + '|mailx -s\"Subject: mta_XMM_alert\n\" ' + ' '.join(ADMIN) 
-        os.system(cmd)
-        rm_file(zspace)
-
     out= xmm_dir + 'Data/alt_trip_records'
     line = str(time) + ': ' + str(chigh) + '\t\t' + str(l1) + '\n'
     #for writing out files in test directory


### PR DESCRIPTION
This PR addresses Issue #44 by removing the secondary email alerting command call while keeping the primary email alerting command call which sends a warning every 18 hours if there is an altitude violation.